### PR TITLE
[stormmore] Add config option for exposing HAProxy stats interface

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -321,3 +321,7 @@ options:
     description: |
       Module that overriding layout for customization.
       This is available from Liberty
+  expose-haproxy-stats:
+    default: False
+    type: boolean
+    description: If True, exposes the HAProxy stats interface globally.

--- a/hooks/horizon_contexts.py
+++ b/hooks/horizon_contexts.py
@@ -90,7 +90,8 @@ class HorizonHAProxyContext(HAProxyContext):
                 'dash_insecure': [80, 70],
                 'dash_secure': [443, 433]
             },
-            'prefer_ipv6': config('prefer-ipv6')
+            'prefer_ipv6': config('prefer-ipv6'),
+            'expose_haproxy_stats': config('expose-haproxy-stats')
         }
         return ctxt
 

--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -34,7 +34,7 @@ defaults
 {%- endif %}
 
 listen stats
-    bind {{ local_host }}:{{ stat_port }}
+    bind {% if expose_haproxy_stats %}{{ haproxy_host }}{% else %}{{ local_host }}{% endif %}:{{ stat_port }}
     mode http
     stats enable
     stats hide-version

--- a/unit_tests/test_horizon_contexts.py
+++ b/unit_tests/test_horizon_contexts.py
@@ -441,7 +441,8 @@ class TestHorizonContexts(CharmTestCase):
                               {'units': {'openstack-dashboard-0': '10.5.0.1'},
                                'service_ports': {'dash_insecure': [80, 70],
                                                  'dash_secure': [443, 433]},
-                               'prefer_ipv6': False})
+                               'prefer_ipv6': False,
+                               'expose_haproxy_stats': False})
             _open.assert_called_with('/etc/default/haproxy', 'w')
             self.assertTrue(_file.write.called)
 
@@ -460,7 +461,23 @@ class TestHorizonContexts(CharmTestCase):
                                          'openstack-dashboard-2': '10.5.0.3'},
                                'service_ports': {'dash_insecure': [80, 70],
                                                  'dash_secure': [443, 433]},
-                               'prefer_ipv6': False})
+                               'prefer_ipv6': False,
+                               'expose_haproxy_stats': False})
+            _open.assert_called_with('/etc/default/haproxy', 'w')
+            self.assertTrue(_file.write.called)
+
+    def test_HorizonHAProxyContext_expose_stats(self):
+        self.test_config.set('expose-haproxy-stats', True)
+        self.relation_ids.return_value = []
+        self.local_unit.return_value = 'openstack-dashboard/0'
+        self.unit_get.return_value = "10.5.0.1"
+        with patch_open() as (_open, _file):
+            self.assertEquals(horizon_contexts.HorizonHAProxyContext()(),
+                              {'units': {'openstack-dashboard-0': '10.5.0.1'},
+                               'service_ports': {'dash_insecure': [80, 70],
+                                                 'dash_secure': [443, 433]},
+                               'prefer_ipv6': False,
+                               'expose_haproxy_stats': True})
             _open.assert_called_with('/etc/default/haproxy', 'w')
             self.assertTrue(_file.write.called)
 


### PR DESCRIPTION
Added expose-haproxy-stats as a configuration option to the charm

Bug: Issue 1710208
Change-Id: I558dc686715e787ae5d95678e1e015355d4f106d